### PR TITLE
ADD:增加支持为arttemplate添加自定义函数功能

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -33,8 +33,9 @@ class Engine {
     if (this.artHelpers && this.artHelpers.length > 0) {
       for (const i in this.artHelpers) {
         const help = this.artHelpers[i];
-        if (help.name && help.callback && typeof help.callback === 'function')
+        if (help.name && help.callback && typeof help.callback === 'function') {
           arttemplate.helper(help.name, help.callback);
+        }
       }
     }
     const render = arttemplate.compile(source, opts);

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ const utils = require('./utils');
 
 
 Object.assign(arttemplate.utils, utils);
-arttemplate.onerror = function (e) {
+arttemplate.onerror = function(e) {
   throw e;
 };
 
@@ -31,14 +31,14 @@ class Engine {
       debug: this.development
     };
     if (this.artHelpers && this.artHelpers.length > 0) {
-      for (let i in this.artHelpers) {
+      for (const i in this.artHelpers) {
         const help = this.artHelpers[i];
-        if (help.name && help.callback && typeof help.callback == 'function')
+        if (help.name && help.callback && typeof help.callback === 'function')
           arttemplate.helper(help.name, help.callback);
       }
     }
     const render = arttemplate.compile(source, opts);
-    return function (context) {
+    return function(context) {
       return render(context, options.path);
     };
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ const utils = require('./utils');
 
 
 Object.assign(arttemplate.utils, utils);
-arttemplate.onerror = function(e) {
+arttemplate.onerror = function (e) {
   throw e;
 };
 
@@ -30,9 +30,15 @@ class Engine {
       compress: this.compress,
       debug: this.development
     };
-
+    if (this.artHelpers && this.artHelpers.length > 0) {
+      for (let i in this.artHelpers) {
+        const help = this.artHelpers[i];
+        if (help.name && help.callback && typeof help.callback == 'function')
+          arttemplate.helper(help.name, help.callback);
+      }
+    }
     const render = arttemplate.compile(source, opts);
-    return function(context) {
+    return function (context) {
       return render(context, options.path);
     };
   }


### PR DESCRIPTION
增加支持arttemplate的自定义函数功能，即让arttemplate的help方法能够接受plover项目配置的自定义函数。
在ploverx项目中的config/app.js可以做如下配置
/**
 * arttemplate配置
 */
exports.arttemplate = {
  // 压缩，去掉html前置多余的空格
  compress: true,
  async: true,
  **artHelpers: [
    {
      name: "getData", callback: function (map, key) {
        return map[key];
      }
    }
  ]**
};