### PR TITLE
添加config view后缀名可配置

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -1,15 +1,18 @@
 'use strict';
 
-
 module.exports = function(app) {
   const settings = app.settings;
   const Engine = require('./index');
 
-  const config = Object.assign({
-    async: true,
-    development: settings.development
-  }, settings.arttemplate);
+  const config = Object.assign(
+    {
+      async: true,
+      development: settings.development
+    },
+    settings.arttemplate
+  );
 
   const engine = new Engine(config);
-  app.addEngine('art', engine);
+  const viewExt = config.viewExt || 'art';
+  app.addEngine(viewExt, engine);
 };

--- a/test/index.js
+++ b/test/index.js
@@ -111,6 +111,7 @@ describe('index', function() {
 
   it('config art', function() {
     const config = {
+      viewExt: 'html',
       compress: true,
       async: true,
       openTag: '<%',


### PR DESCRIPTION
之前engine 的name是写死的art，所有view必须以.art结尾才可以，现可传入view的extName，来当做engine的name